### PR TITLE
adding ports description to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Unreleased]
+- Adding ports description to README. [Issue #7](https://github.com/nimbux911/terraform-aws-gitlab/issues/7)
+
 ## [1.0.1] - 2022-12-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Running this example creates a running instance of Gitlab with the following cha
    - Docker, docker-compose and certbot are installed during the deployment.
    - Certbot uses the dns-route53 plugin to create the certificate for the required domain. 
    - Gitlab is running on a single EC2 instance on AWS.
+   - By default EC2 instances have port 22 taken for SSH access. So **port 2222** is used instead for git access. You can see this configured in [docker-compose.tpl](./resources/templates/docker-compose.yml.tpl)
+   - **Port 443** is used for web access
    - Automated backups using AWS Backup
    - Automated restore from snapshot
    - Automated certificate renewal through certbot


### PR DESCRIPTION
## [Unreleased]
- Adding ports description to README. [Issue #7](https://github.com/nimbux911/terraform-aws-gitlab/issues/7)

## [1.0.1] - 2022-12-30
