### PR TITLE
fix renewal certificate logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.0.2] - 2022-10-31
+
+### Added
+
+- Fix renewal certificate logic
+
 ## [1.0.1] - 2022-12-30
 
 ### Added

--- a/main.tf
+++ b/main.tf
@@ -159,6 +159,7 @@ resource "aws_launch_template" "gitlab" {
       docker_compose_yml  = base64encode(templatefile("${path.module}/resources/templates/docker-compose.yml.tpl", 
         {
           host_domain = var.host_domain
+          gitlab_container_name = var.gitlab_container_name
         })),
       install_script      = base64encode(templatefile("${path.module}/resources/scripts/install.sh",
         {
@@ -181,6 +182,7 @@ resource "aws_launch_template" "gitlab" {
         {
           certbot_email   = var.certbot_email
           host_domain     = var.host_domain
+          gitlab_container_name = var.gitlab_container_name
         }))
     }
   ))

--- a/resources/scripts/renew.sh
+++ b/resources/scripts/renew.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 export GITLAB_HOME="/srv/gitlab"
-gitlab_container=$(docker ps --format '{{.Names}}' | grep gitlab)
 
 m1=$(md5sum "/etc/letsencrypt/live/${host_domain}/fullchain.pem" | awk '{print $1}')
 m2=$(md5sum "$GITLAB_HOME/config/ssl/${host_domain}.crt" | awk '{print $1}')
@@ -9,5 +8,5 @@ m2=$(md5sum "$GITLAB_HOME/config/ssl/${host_domain}.crt" | awk '{print $1}')
 if [ "$m1" != "$m2" ]; then
     cp /etc/letsencrypt/live/${host_domain}/fullchain.pem $GITLAB_HOME/config/ssl/${host_domain}.crt
     cp /etc/letsencrypt/live/${host_domain}/privkey.pem $GITLAB_HOME/config/ssl/${host_domain}.key
-    docker exec $gitlab_container gitlab-ctl restart nginx
+    docker exec ${gitlab_container_name} gitlab-ctl restart nginx
 fi

--- a/resources/scripts/renew.sh
+++ b/resources/scripts/renew.sh
@@ -1,14 +1,13 @@
 #!/bin/bash
 
 export GITLAB_HOME="/srv/gitlab"
+gitlab_container=$(docker ps --format '{{.Names}}' | grep gitlab)
 
-m1=$(md5sum "/etc/letsencrypt/live/${host_domain}/fullchain.pem")
-
-certbot certonly --non-interactive --agree-tos --email ${certbot_email} --no-redirect --dns-route53 -d ${host_domain}
-
-m2=$(md5sum "/etc/letsencrypt/live/${host_domain}/fullchain.pem")
+m1=$(md5sum "/etc/letsencrypt/live/${host_domain}/fullchain.pem" | awk '{print $1}')
+m2=$(md5sum "$GITLAB_HOME/config/ssl/${host_domain}.crt" | awk '{print $1}')
 
 if [ "$m1" != "$m2" ]; then
     cp /etc/letsencrypt/live/${host_domain}/fullchain.pem $GITLAB_HOME/config/ssl/${host_domain}.crt
     cp /etc/letsencrypt/live/${host_domain}/privkey.pem $GITLAB_HOME/config/ssl/${host_domain}.key
+    docker exec $gitlab_container gitlab-ctl restart nginx
 fi

--- a/resources/templates/docker-compose.yml.tpl
+++ b/resources/templates/docker-compose.yml.tpl
@@ -3,7 +3,7 @@ services:
   gitlab:
     image: 'gitlab/gitlab-ce:15.2.5-ce.0'
     hostname: '${host_domain}'
-    container_name: gitlab
+    container_name: ${gitlab_container_name}
     environment:
       GITLAB_OMNIBUS_CONFIG: |
         external_url 'https://${host_domain}'

--- a/variables.tf
+++ b/variables.tf
@@ -43,3 +43,8 @@ variable "swap_volume_size" {
     type    = number
     default = 8
 }
+
+variable "gitlab_container_name" {
+    type = string
+    default = "gitlab"
+}


### PR DESCRIPTION
- Remove the certbot command in the middle since certbot already has by default a cronjob running every 12hrs.
- Compare origin cert with destination cert md5sum
- Restart the nginx inside the gitlab container so the copied cert can be used.